### PR TITLE
Bump package version to 0.1.4

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "mcat-cli"
-version = "0.1.2"
+version = "0.1.4"
 description = "The model-context access tool for agents and humans"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -55,7 +55,7 @@ wheels = [
 
 [[package]]
 name = "mcat-cli"
-version = "0.1.2"
+version = "0.1.4"
 source = { editable = "." }
 dependencies = [
     { name = "json5" },


### PR DESCRIPTION
## Summary
- bump package version from 0.1.2 to 0.1.4 in pyproject and lock metadata
- unblock PyPI publish after v0.1.3 attempted to upload existing 0.1.2 files