### PR TITLE
Fix #8: allow mcat init options after ENDPOINT

### DIFF
--- a/src/mcat_cli/app.py
+++ b/src/mcat_cli/app.py
@@ -166,7 +166,7 @@ def auth_continue(
     )
 
 
-init_cmd = typer.Typer()
+init_cmd = typer.Typer(context_settings={"allow_interspersed_args": True})
 
 
 @init_cmd.callback(invoke_without_command=True)


### PR DESCRIPTION
## Summary
Fixes #8 by allowing `mcat init` options (`-k/--key-ref`, `-o/--out`) to be parsed correctly when they appear after `ENDPOINT`.

## Root cause
`init` is implemented as a Typer callback on a sub-`Typer` (group). Click group parsing in this shape did not intersperse group options after positional args, so `-k/-o` were treated as missing when placed after endpoint.

## Change
- Set `allow_interspersed_args=True` for `init_cmd` context settings.

```python
init_cmd = typer.Typer(context_settings={"allow_interspersed_args": True})
```

## Verification
Tested both invocation orders locally:

1. Works (previously failed parsing):
```bash
uv run mcat init https://example.com/mcp -k token.json -o sess.out.json
```

2. Still works:
```bash
uv run mcat init -k token.json -o sess.out.json https://example.com/mcp
```

Both now proceed into network execution (expected downstream 405 against example.com), confirming argument parsing is fixed.

## Scope
This PR is intentionally scoped to issue #8 only.
