### PR TITLE
Fix #9: correct mcat init help usage signature

### DIFF
--- a/src/mcat_cli/app.py
+++ b/src/mcat_cli/app.py
@@ -166,18 +166,12 @@ def auth_continue(
     )
 
 
-init_cmd = typer.Typer(context_settings={"allow_interspersed_args": True})
-
-
-@init_cmd.callback(invoke_without_command=True)
 def init_default(
     ctx: typer.Context,
     endpoint: EndpointArg,
     key_ref: KeyRefOpt,
     sess_info_file: SessionInfoOutOpt,
 ) -> None:
-    if ctx.invoked_subcommand is not None:
-        return
     _ = _runtime(ctx)
     _run_json_command(
         lambda: mcp_mod.init_session(
@@ -346,7 +340,7 @@ app = typer.Typer(
     **conf,
 )
 app.add_typer(auth_cmd, name="auth", help="Authorize MCP server access.", **conf)
-app.add_typer(init_cmd, name="init", help="Initialize MCP sessions.", **conf)
+app.command("init", help="Initialize MCP sessions.")(init_default)
 app.add_typer(tool_cmd, name="tool", help="Use MCP tools.", **conf)
 app.add_typer(resource_cmd, name="resource", help="Use MCP resources.", **conf)
 app.add_typer(prompt_cmd, name="prompt", help="Use MCP prompts.", **conf)


### PR DESCRIPTION
## Summary
Fixes #9 by making `init` a direct command instead of a callback-only sub-group.

## Problem
`init` was wired as a Typer group callback (`@init_cmd.callback(invoke_without_command=True)`). Click/Typer renders group usage as:

```text
mcat init [OPTIONS] ENDPOINT COMMAND [ARGS]...
```

which is misleading because `init` has no subcommands.

## Change
- Removed callback-group registration for `init`.
- Registered `init_default` directly on the root app:

```python
app.command("init", help="Initialize MCP sessions.")(init_default)
```

## Result
`mcat init --help` now shows:

```text
Usage: mcat init [OPTIONS] ENDPOINT
```

## Verification
- `uv run mcat init --help` now prints correct usage.
- `uv run mcat init https://example.com/mcp -k token.json -o sess.issue9.a.json` parses and runs.
- `uv run mcat init -k token.json -o sess.issue9.b.json https://example.com/mcp` parses and runs.

Both invocation orders continue to work (request proceeds to expected network 405 against example.com).

Closes #9.
