### PR TITLE
Add OAuth client override precedence and key-ref client config

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,35 +73,42 @@ For auth flows, token output is written back to `--key-ref`.
 
 ## OAuth Client Config (Optional)
 
-`mcat auth start` accepts optional client overrides:
+`mcat auth start` accepts optional client configuration inputs:
+- `-c/--client path/to/client-info.json`
 - `--client-id`
 - `--client-secret`
 - `--client-name`
 
 Resolution order is deterministic:
 1. CLI overrides
-2. `--key-ref` JSON `_oauth_client` block
-3. Legacy top-level JSON fields (backward compatibility)
-4. Built-in defaults
+2. `--client` JSON file
+3. Built-in defaults
 
 If a resolved `client_id` exists, mcat uses static client mode and skips dynamic registration.
 If no `client_id` is resolved, mcat attempts dynamic registration once using resolved
-`client_name` (`--client-name` > `_oauth_client.client_name` > default).
+`client_name` (`--client-name` > `client.name` > default).
 
-Example key-ref JSON:
+`--key-ref` remains token storage only. Client config is not read from key-ref.
+
+Example client info files:
+
+```json
+{"name":"Codex"}
+```
 
 ```json
 {
-  "access_token": "...",
-  "_oauth_client": {
-    "client_id": "...",
-    "client_secret": "...",
-    "client_name": "Codex",
-    "scope": "mcp:connect",
-    "resource": "https://mcp.figma.com/mcp"
-  }
+  "id": "abc123",
+  "secret": "env://FIGMA_CLIENT_SECRET",
+  "scope": "mcp:connect",
+  "resource": "https://mcp.figma.com/mcp"
 }
 ```
+
+Validation rules:
+- `name` conflicts with `id`/`secret`.
+- `--client-name` conflicts with `--client-id`/`--client-secret`.
+- `secret` (or `--client-secret`) requires `id` (or `--client-id`).
 
 ## Output Contract
 

--- a/docs/design.md
+++ b/docs/design.md
@@ -24,7 +24,7 @@ Design priorities:
 ## Command Surface (v1)
 
 ```bash
-mcat [GLOBAL_OPTS] auth start ENDPOINT -k KEY_REF --state AUTH_STATE_FILE [--wait] [-o] [--client-id CLIENT_ID] [--client-secret CLIENT_SECRET] [--client-name CLIENT_NAME]
+mcat [GLOBAL_OPTS] auth start ENDPOINT -k KEY_REF --state AUTH_STATE_FILE [--wait] [-o] [-c CLIENT_INFO_FILE] [--client-id CLIENT_ID] [--client-secret KEY_SPEC] [--client-name CLIENT_NAME]
 mcat [GLOBAL_OPTS] auth continue --state AUTH_STATE_FILE -k KEY_REF [-o]
 
 mcat [GLOBAL_OPTS] init ENDPOINT -k KEY_REF -o SESS_INFO_FILE
@@ -55,7 +55,7 @@ Notes:
 - `-k / --key-ref` is required for `auth start` and `auth continue`.
 - `auth` defaults to non-blocking behavior; pass `--wait` to block/poll until completion.
 - `-o / --overwrite` allows replacing an existing `KEY_REF` value when persisting tokens.
-- `auth start` supports optional OAuth client overrides via `--client-id`, `--client-secret`, `--client-name`.
+- `auth start` supports optional OAuth client config via `-c/--client` and overrides via `--client-id`, `--client-secret`, `--client-name`.
 
 ## JSON Output Contract
 
@@ -164,11 +164,14 @@ Auth-specific behavior:
 
 OAuth client config behavior:
 
-- Optional static/dynamic OAuth client config may be provided in key-ref JSON under `_oauth_client`.
-- Supported `_oauth_client` fields: `client_id`, `client_secret`, `client_name`, `scope`, `resource`, `audience`.
-- Resolution precedence is: CLI override > `_oauth_client` > legacy top-level fields > defaults.
+- Optional OAuth client config is provided via `-c/--client` JSON file.
+- Supported client file fields: `id` (or `client_id`), `secret` (or `client_secret`), `name` (or `client_name`), `scope`, `resource`, `audience`.
+- Resolution precedence is: CLI override > `--client` file > defaults.
 - If resolved `client_id` exists, use static client mode and skip dynamic client registration.
 - If resolved `client_id` does not exist, attempt dynamic registration exactly once with resolved `client_name`.
+- Conflict rule: `name` cannot be combined with `id`/`secret` (same for CLI options).
+- `secret` requires `id` (same for `--client-secret` + `--client-id`).
+- `--key-ref` is used for token read/write only, not client config.
 
 Constraints:
 

--- a/src/mcat_cli/app.py
+++ b/src/mcat_cli/app.py
@@ -62,20 +62,29 @@ AuthStateFileOpt = Annotated[
     str,
     typer.Option("--state", metavar="AUTH_STATE_FILE", help="Path to auth state file."),
 ]
+AuthClientRefOpt = Annotated[
+    str | None,
+    typer.Option(
+        "-c",
+        "--client",
+        metavar="CLIENT_INFO_FILE",
+        help="Path to OAuth client info JSON file.",
+    ),
+]
 AuthClientIdOpt = Annotated[
     str | None,
     typer.Option(
         "--client-id",
-        metavar="CLIENT_ID",
-        help="OAuth client_id override (uses static client mode).",
+        metavar="ID",
+        help="OAuth client id override (static client mode).",
     ),
 ]
 AuthClientSecretOpt = Annotated[
     str | None,
     typer.Option(
         "--client-secret",
-        metavar="CLIENT_SECRET",
-        help="OAuth client_secret override (requires a client_id).",
+        metavar="KEY_SPEC",
+        help="OAuth client secret override (KEY_SPEC or literal; requires client id).",
     ),
 ]
 AuthClientNameOpt = Annotated[
@@ -156,6 +165,7 @@ def auth_start(
     endpoint: EndpointArg,
     key_ref: KeyRefOpt,
     state_file: AuthStateFileOpt,
+    client: AuthClientRefOpt = None,
     client_id: AuthClientIdOpt = None,
     client_secret: AuthClientSecretOpt = None,
     client_name: AuthClientNameOpt = None,
@@ -172,6 +182,7 @@ def auth_start(
             state_file=state_file,
             wait=wait,
             overwrite=overwrite,
+            client_ref=client,
             client_id_override=client_id,
             client_secret_override=client_secret,
             client_name_override=client_name,


### PR DESCRIPTION
## Summary
- add dedicated OAuth client input file option: `-c/--client CLIENT_INFO_FILE`
- keep explicit overrides: `--client-id`, `--client-secret`, `--client-name`
- remove client-config loading from `--key-ref` payload (`--key-ref` is token storage only)

## Client config model
- `--client` JSON fields:
  - static mode: `id`/`client_id` + optional `secret`/`client_secret`
  - dynamic mode: `name`/`client_name`
  - optional: `scope`, `resource`, `audience`
- precedence: `CLI overrides > --client file > defaults`
- conflict rules:
  - `name` conflicts with `id`/`secret` (same for CLI flags)
  - `secret` requires `id` (same for CLI flags)

## Runtime behavior
- resolved `client_id` => static mode (skip dynamic registration)
- no `client_id` => dynamic registration, single attempt only
- DCR 401/403 message includes attempted `client_name` and source

## Validation
- `python -m compileall -q src/mcat_cli`
- `uv run mcat auth start --help` includes `-c/--client`
- conflict checks return explicit errors
- live smoke:
  - Linear default dynamic registration still succeeds
  - Figma succeeds with `-c` file `{ "name": "Codex" }`

Closes #16