### PR TITLE
refactor: extract OAuth discovery candidate builders

### DIFF
--- a/src/mcat_cli/util/oauth_discovery.py
+++ b/src/mcat_cli/util/oauth_discovery.py
@@ -1,0 +1,89 @@
+from __future__ import annotations
+
+from urllib import parse as urlparse
+
+
+def build_protected_resource_metadata_urls(
+    endpoint: str, *, hinted_resource_metadata: str | None = None
+) -> list[str]:
+    candidates: list[str] = []
+
+    hinted = hinted_resource_metadata.strip() if hinted_resource_metadata else ""
+    if hinted:
+        candidates.append(hinted)
+
+    parsed = urlparse.urlsplit(endpoint)
+    if not parsed.scheme or not parsed.netloc:
+        return _dedupe(candidates)
+
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    path = parsed.path.strip("/")
+    if path:
+        candidates.append(f"{base}/.well-known/oauth-protected-resource/{path}")
+    candidates.append(f"{base}/.well-known/oauth-protected-resource")
+    return _dedupe(candidates)
+
+
+def build_issuer_candidates(
+    endpoint: str,
+    *,
+    discovered_authorization_servers: list[str],
+    hinted_issuer: str | None,
+) -> list[str]:
+    candidates: list[str] = []
+    candidates.extend(
+        issuer
+        for issuer in discovered_authorization_servers
+        if isinstance(issuer, str) and issuer.strip()
+    )
+
+    hinted = hinted_issuer.strip() if hinted_issuer else ""
+    if hinted:
+        candidates.append(hinted)
+
+    host_issuer = _mcp_host_issuer(endpoint)
+    if not candidates:
+        candidates.append(endpoint)
+    if host_issuer:
+        candidates.append(host_issuer)
+
+    return _dedupe(candidates)
+
+
+def build_authorization_server_metadata_urls(issuer: str) -> list[str]:
+    issuer = issuer.rstrip("/")
+    parsed = urlparse.urlsplit(issuer)
+    if not parsed.scheme or not parsed.netloc:
+        return []
+
+    base = f"{parsed.scheme}://{parsed.netloc}"
+    path = parsed.path.strip("/")
+    urls: list[str] = []
+    if path:
+        urls.append(f"{base}/.well-known/oauth-authorization-server/{path}")
+        urls.append(f"{base}/.well-known/openid-configuration/{path}")
+        urls.append(f"{issuer}/.well-known/oauth-authorization-server")
+        urls.append(f"{issuer}/.well-known/openid-configuration")
+    else:
+        urls.append(f"{issuer}/.well-known/oauth-authorization-server")
+        urls.append(f"{issuer}/.well-known/openid-configuration")
+    # Some servers expose metadata directly at the issuer URL.
+    urls.append(issuer)
+    return _dedupe(urls)
+
+
+def _mcp_host_issuer(endpoint: str) -> str | None:
+    parsed = urlparse.urlsplit(endpoint)
+    if not parsed.scheme or not parsed.netloc:
+        return None
+    return f"{parsed.scheme}://{parsed.netloc}"
+
+
+def _dedupe(values: list[str]) -> list[str]:
+    seen: set[str] = set()
+    out: list[str] = []
+    for value in values:
+        if value not in seen:
+            out.append(value)
+            seen.add(value)
+    return out

--- a/tests/test_oauth_discovery.py
+++ b/tests/test_oauth_discovery.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import unittest
+
+from mcat_cli.util.oauth_discovery import (
+    build_authorization_server_metadata_urls,
+    build_issuer_candidates,
+    build_protected_resource_metadata_urls,
+)
+
+
+class OAuthDiscoveryCandidatesTest(unittest.TestCase):
+    def test_build_protected_resource_metadata_urls_with_path(self) -> None:
+        endpoint = "https://mcp.linear.app/mcp"
+
+        self.assertEqual(
+            build_protected_resource_metadata_urls(endpoint),
+            [
+                "https://mcp.linear.app/.well-known/oauth-protected-resource/mcp",
+                "https://mcp.linear.app/.well-known/oauth-protected-resource",
+            ],
+        )
+
+    def test_build_protected_resource_metadata_urls_with_hint(self) -> None:
+        endpoint = "https://mcp.linear.app/mcp"
+        hinted = "https://hinted.example/.well-known/oauth-protected-resource"
+
+        self.assertEqual(
+            build_protected_resource_metadata_urls(
+                endpoint,
+                hinted_resource_metadata=hinted,
+            ),
+            [
+                hinted,
+                "https://mcp.linear.app/.well-known/oauth-protected-resource/mcp",
+                "https://mcp.linear.app/.well-known/oauth-protected-resource",
+            ],
+        )
+
+    def test_build_authorization_server_metadata_urls_with_path(self) -> None:
+        issuer = "https://api.figma.com/v1/oauth"
+
+        self.assertEqual(
+            build_authorization_server_metadata_urls(issuer),
+            [
+                "https://api.figma.com/.well-known/oauth-authorization-server/v1/oauth",
+                "https://api.figma.com/.well-known/openid-configuration/v1/oauth",
+                "https://api.figma.com/v1/oauth/.well-known/oauth-authorization-server",
+                "https://api.figma.com/v1/oauth/.well-known/openid-configuration",
+                "https://api.figma.com/v1/oauth",
+            ],
+        )
+
+    def test_build_authorization_server_metadata_urls_no_path(self) -> None:
+        issuer = "https://mcp.linear.app"
+
+        self.assertEqual(
+            build_authorization_server_metadata_urls(issuer),
+            [
+                "https://mcp.linear.app/.well-known/oauth-authorization-server",
+                "https://mcp.linear.app/.well-known/openid-configuration",
+                "https://mcp.linear.app",
+            ],
+        )
+
+    def test_build_issuer_candidates_fallback(self) -> None:
+        endpoint = "https://mcp.linear.app/mcp"
+
+        self.assertEqual(
+            build_issuer_candidates(
+                endpoint,
+                discovered_authorization_servers=[],
+                hinted_issuer=None,
+            ),
+            [
+                "https://mcp.linear.app/mcp",
+                "https://mcp.linear.app",
+            ],
+        )
+
+    def test_build_issuer_candidates_prefers_discovery_then_hint(self) -> None:
+        endpoint = "https://mcp.linear.app/mcp"
+
+        self.assertEqual(
+            build_issuer_candidates(
+                endpoint,
+                discovered_authorization_servers=[
+                    "https://issuer-a.example",
+                    "https://issuer-b.example",
+                ],
+                hinted_issuer="https://hinted.example",
+            ),
+            [
+                "https://issuer-a.example",
+                "https://issuer-b.example",
+                "https://hinted.example",
+                "https://mcp.linear.app",
+            ],
+        )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- extract OAuth discovery candidate generation into src/mcat_cli/util/oauth_discovery.py
- keep auth discovery flow explicit as: generate candidates -> fetch -> select
- replace inline URL/issuer helper logic in src/mcat_cli/auth.py with utility calls
- add unit tests for candidate ordering and fallback behavior

## Validation
- PYTHONPATH=src python -m unittest discover -s tests -p 'test_*.py'
- uv run ruff check

Part of #24.