### PR TITLE
refactor: extract client info file module

### DIFF
--- a/src/mcat_cli/util/client_info.py
+++ b/src/mcat_cli/util/client_info.py
@@ -1,0 +1,101 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+from .common import as_optional_str
+from .key_ref import KeyRefNotFoundError, read_key_ref_value
+
+
+@dataclass(frozen=True, slots=True)
+class ClientInfoFile:
+    client_id: str | None
+    client_secret_spec: str | None
+    client_name: str | None
+    scope: str | None
+    audience: str | None
+    resource: str | None
+
+
+def read_client_info_file(client_ref: str | None) -> ClientInfoFile:
+    client_doc = _read_client_info_doc(client_ref)
+    file_id = _extract_client_alias_string(client_doc, keys=("id", "client_id"))
+    file_secret_spec = _extract_client_alias_string(
+        client_doc, keys=("secret", "client_secret")
+    )
+    file_name = _extract_client_alias_string(client_doc, keys=("name", "client_name"))
+    file_scope = _coerce_scope_value(client_doc.get("scope", client_doc.get("scopes")))
+    file_audience = _extract_client_alias_string(client_doc, keys=("audience",))
+    file_resource = _extract_client_alias_string(client_doc, keys=("resource",))
+
+    if file_name and (file_id or file_secret_spec):
+        raise ValueError(
+            "client info file cannot combine name with id/client_id or secret/client_secret"
+        )
+    if file_secret_spec and not file_id:
+        raise ValueError("client info file secret/client_secret requires id/client_id")
+
+    return ClientInfoFile(
+        client_id=file_id,
+        client_secret_spec=file_secret_spec,
+        client_name=file_name,
+        scope=file_scope,
+        audience=file_audience,
+        resource=file_resource,
+    )
+
+
+def resolve_client_secret_spec(secret_spec: str) -> str:
+    if "://" not in secret_spec:
+        return secret_spec
+    try:
+        payload = read_key_ref_value(secret_spec)
+    except KeyRefNotFoundError:
+        raise ValueError(f"client secret KEY_SPEC not found: {secret_spec}") from None
+    direct = as_optional_str(payload)
+    if direct:
+        return direct
+    if isinstance(payload, dict):
+        extracted = (
+            as_optional_str(payload.get("secret"))
+            or as_optional_str(payload.get("client_secret"))
+            or as_optional_str(payload.get("value"))
+        )
+        if extracted:
+            return extracted
+    raise ValueError(
+        f"client secret KEY_SPEC must resolve to a string "
+        f'or object with "secret"/"client_secret"/"value": {secret_spec}'
+    )
+
+
+def _read_client_info_doc(client_ref: str | None) -> dict[str, Any]:
+    if not as_optional_str(client_ref):
+        return {}
+    assert client_ref is not None
+    try:
+        payload = read_key_ref_value(client_ref)
+    except KeyRefNotFoundError:
+        raise ValueError(f"client info file not found: {client_ref}") from None
+    if not isinstance(payload, dict):
+        raise ValueError("client info file must contain a JSON object")
+    return payload
+
+
+def _extract_client_alias_string(
+    payload: dict[str, Any], *, keys: tuple[str, ...]
+) -> str | None:
+    for key in keys:
+        value = as_optional_str(payload.get(key))
+        if value:
+            return value
+    return None
+
+
+def _coerce_scope_value(value: Any) -> str | None:
+    if isinstance(value, list):
+        parts = [str(x).strip() for x in value if str(x).strip()]
+        return " ".join(parts) if parts else None
+    if isinstance(value, str):
+        return value.strip() or None
+    return None

--- a/tests/test_client_info.py
+++ b/tests/test_client_info.py
@@ -1,0 +1,97 @@
+from __future__ import annotations
+
+import json
+import tempfile
+import unittest
+from pathlib import Path
+
+from mcat_cli.util.client_info import (
+    read_client_info_file,
+    resolve_client_secret_spec,
+)
+
+
+class ClientInfoFileTest(unittest.TestCase):
+    def test_read_client_info_file_empty_ref(self) -> None:
+        info = read_client_info_file(None)
+        self.assertIsNone(info.client_id)
+        self.assertIsNone(info.client_secret_spec)
+        self.assertIsNone(info.client_name)
+        self.assertIsNone(info.scope)
+        self.assertIsNone(info.audience)
+        self.assertIsNone(info.resource)
+
+    def test_read_client_info_file_name_mode(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            client_file = Path(temp_dir) / "client.json"
+            client_file.write_text(
+                json.dumps(
+                    {
+                        "name": "mcat-cli",
+                        "scopes": ["mcp:connect", "offline_access"],
+                        "audience": "example-api",
+                        "resource": "https://example.com/mcp",
+                    }
+                ),
+                encoding="utf-8",
+            )
+
+            info = read_client_info_file(str(client_file))
+
+            self.assertEqual(info.client_name, "mcat-cli")
+            self.assertEqual(info.scope, "mcp:connect offline_access")
+            self.assertEqual(info.audience, "example-api")
+            self.assertEqual(info.resource, "https://example.com/mcp")
+
+    def test_read_client_info_file_rejects_name_with_id(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            client_file = Path(temp_dir) / "client.json"
+            client_file.write_text(
+                json.dumps({"name": "named-client", "id": "abc"}),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "client info file cannot combine name with id/client_id or secret/client_secret",
+            ):
+                read_client_info_file(str(client_file))
+
+    def test_read_client_info_file_rejects_secret_without_id(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            client_file = Path(temp_dir) / "client.json"
+            client_file.write_text(
+                json.dumps({"secret": "topsecret"}),
+                encoding="utf-8",
+            )
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "client info file secret/client_secret requires id/client_id",
+            ):
+                read_client_info_file(str(client_file))
+
+    def test_resolve_client_secret_spec_literal(self) -> None:
+        self.assertEqual(resolve_client_secret_spec("plain-secret"), "plain-secret")
+
+    def test_resolve_client_secret_spec_key_spec(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            secret_file = Path(temp_dir) / "secret.json"
+            secret_file.write_text(
+                json.dumps({"client_secret": "from-file"}),
+                encoding="utf-8",
+            )
+
+            resolved = resolve_client_secret_spec(f"json://{secret_file}")
+            self.assertEqual(resolved, "from-file")
+
+    def test_resolve_client_secret_spec_missing_key_spec(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError,
+            "client secret KEY_SPEC not found: json://missing-file.json",
+        ):
+            resolve_client_secret_spec("json://missing-file.json")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add src/mcat_cli/util/client_info.py as the dedicated module for client info file parsing/validation
- move client info file field extraction and file-level validation out of auth.py
- move client secret KEY_SPEC resolution helper into the same client-info utility module
- simplify auth.py client config merge logic to consume parsed client info data
- add unit tests for client info load/validation and secret resolution

## Validation
- PYTHONPATH=src python -m unittest discover -s tests -p 'test_*.py'
- uv run ruff check

Part of #24.