### PR TITLE
refactor: centralize JSON object file helpers

### DIFF
--- a/src/mcat_cli/util/auth_state.py
+++ b/src/mcat_cli/util/auth_state.py
@@ -1,34 +1,28 @@
 from __future__ import annotations
 
-import json
 import os
 import tempfile
 from pathlib import Path
 from typing import Any
 
-from .atomic_files import locked_file, write_text_atomic
+from .json_file import read_json_object, write_json_object_locked
 
 
 def read_auth_state_file(path: str) -> dict[str, Any]:
-    try:
-        data = json.loads(Path(path).read_text(encoding="utf-8"))
-    except FileNotFoundError:
-        raise ValueError(f"auth state file not found: {path}") from None
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"invalid auth state file JSON: {exc.msg}") from None
-    if not isinstance(data, dict):
-        raise ValueError("invalid auth state file: expected object")
-    return data
+    return read_json_object(
+        path,
+        not_found_message=f"auth state file not found: {path}",
+        invalid_json_prefix="invalid auth state file JSON",
+        expected_object_message="invalid auth state file: expected object",
+    )
 
 
 def write_auth_state_file(path: str, state_doc: dict[str, Any]) -> None:
-    lock_path = f"{path}.lock"
-    content = json.dumps(state_doc, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
-    try:
-        with locked_file(lock_path):
-            write_text_atomic(path, content)
-    except BlockingIOError:
-        raise ValueError(f"auth state file is busy: {path}") from None
+    write_json_object_locked(
+        path,
+        state_doc,
+        busy_message=f"auth state file is busy: {path}",
+    )
 
 
 def default_auth_state_file() -> str:

--- a/src/mcat_cli/util/json_file.py
+++ b/src/mcat_cli/util/json_file.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+from .atomic_files import locked_file, write_text_atomic
+
+
+def read_json_object(
+    path: str,
+    *,
+    not_found_message: str,
+    invalid_json_prefix: str,
+    expected_object_message: str,
+    read_error_prefix: str | None = None,
+) -> dict[str, Any]:
+    file_path = Path(path)
+    try:
+        raw = file_path.read_text(encoding="utf-8")
+    except FileNotFoundError:
+        raise ValueError(not_found_message) from None
+    except OSError as exc:
+        if read_error_prefix is not None:
+            raise ValueError(f"{read_error_prefix}: {exc}") from None
+        raise
+
+    try:
+        parsed = json.loads(raw)
+    except json.JSONDecodeError as exc:
+        raise ValueError(f"{invalid_json_prefix}: {exc.msg}") from None
+
+    if not isinstance(parsed, dict):
+        raise ValueError(expected_object_message)
+    return parsed
+
+
+def write_json_object_locked(
+    path: str,
+    payload: dict[str, Any],
+    *,
+    busy_message: str,
+) -> None:
+    serialized = json.dumps(payload, indent=2, ensure_ascii=False, sort_keys=True) + "\n"
+    lock_path = f"{path}.lock"
+    try:
+        with locked_file(lock_path):
+            write_text_atomic(path, serialized)
+    except BlockingIOError:
+        raise ValueError(busy_message) from None

--- a/src/mcat_cli/util/session_info.py
+++ b/src/mcat_cli/util/session_info.py
@@ -1,44 +1,23 @@
 from __future__ import annotations
 
-import json
-from pathlib import Path
 from typing import Any
 
-from .atomic_files import locked_file, write_text_atomic
+from .json_file import read_json_object, write_json_object_locked
 
 
 def read_session_info(path: str) -> dict[str, Any]:
-    p = Path(path)
-    try:
-        raw = p.read_text(encoding="utf-8")
-    except FileNotFoundError:
-        raise ValueError(f"session info file not found: {path}") from None
-    except OSError as exc:
-        raise ValueError(f"unable to read session info file: {exc}") from None
-
-    try:
-        info = json.loads(raw)
-    except json.JSONDecodeError as exc:
-        raise ValueError(f"invalid session info JSON: {exc.msg}") from None
-
-    if not isinstance(info, dict):
-        raise ValueError("invalid session info file: expected JSON object")
-    return info
+    return read_json_object(
+        path,
+        not_found_message=f"session info file not found: {path}",
+        invalid_json_prefix="invalid session info JSON",
+        expected_object_message="invalid session info file: expected JSON object",
+        read_error_prefix="unable to read session info file",
+    )
 
 
 def write_session_info(path: str, session_info: dict[str, Any]) -> None:
-    serialized = (
-        json.dumps(
-            session_info,
-            indent=2,
-            ensure_ascii=False,
-            sort_keys=True,
-        )
-        + "\n"
+    write_json_object_locked(
+        path,
+        session_info,
+        busy_message=f"session info file is busy: {path}",
     )
-    lock_path = f"{path}.lock"
-    try:
-        with locked_file(lock_path):
-            write_text_atomic(path, serialized)
-    except BlockingIOError:
-        raise ValueError(f"session info file is busy: {path}") from None

--- a/tests/test_json_file.py
+++ b/tests/test_json_file.py
@@ -1,0 +1,94 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from mcat_cli.util.json_file import read_json_object, write_json_object_locked
+
+
+class JsonFileTest(unittest.TestCase):
+    def test_read_json_object_not_found(self) -> None:
+        with self.assertRaisesRegex(ValueError, "auth state file not found: missing.json"):
+            read_json_object(
+                "missing.json",
+                not_found_message="auth state file not found: missing.json",
+                invalid_json_prefix="invalid auth state file JSON",
+                expected_object_message="invalid auth state file: expected object",
+            )
+
+    def test_read_json_object_invalid_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "bad.json"
+            path.write_text("{", encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "invalid session info JSON: Expecting property name enclosed in double quotes",
+            ):
+                read_json_object(
+                    str(path),
+                    not_found_message=f"session info file not found: {path}",
+                    invalid_json_prefix="invalid session info JSON",
+                    expected_object_message="invalid session info file: expected JSON object",
+                )
+
+    def test_read_json_object_non_object(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "list.json"
+            path.write_text("[]", encoding="utf-8")
+
+            with self.assertRaisesRegex(
+                ValueError,
+                "invalid auth state file: expected object",
+            ):
+                read_json_object(
+                    str(path),
+                    not_found_message=f"auth state file not found: {path}",
+                    invalid_json_prefix="invalid auth state file JSON",
+                    expected_object_message="invalid auth state file: expected object",
+                )
+
+    def test_read_json_object_read_error_prefix(self) -> None:
+        with mock.patch(
+            "pathlib.Path.read_text", side_effect=OSError("permission denied")
+        ):
+            with self.assertRaisesRegex(
+                ValueError, "unable to read session info file: permission denied"
+            ):
+                read_json_object(
+                    "session.json",
+                    not_found_message="session info file not found: session.json",
+                    invalid_json_prefix="invalid session info JSON",
+                    expected_object_message="invalid session info file: expected JSON object",
+                    read_error_prefix="unable to read session info file",
+                )
+
+    def test_write_json_object_locked_writes_canonical_json(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "state.json"
+
+            write_json_object_locked(
+                str(path),
+                {"b": 2, "a": 1},
+                busy_message=f"auth state file is busy: {path}",
+            )
+
+            self.assertEqual(path.read_text(encoding="utf-8"), '{\n  "a": 1,\n  "b": 2\n}\n')
+
+    def test_write_json_object_locked_busy(self) -> None:
+        def raise_busy(_path: str):
+            raise BlockingIOError
+
+        with mock.patch("mcat_cli.util.json_file.locked_file", side_effect=raise_busy):
+            with self.assertRaisesRegex(ValueError, "session info file is busy: session.json"):
+                write_json_object_locked(
+                    "session.json",
+                    {"a": 1},
+                    busy_message="session info file is busy: session.json",
+                )
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add src/mcat_cli/util/json_file.py as shared JSON object read/write helper module
- refactor src/mcat_cli/util/auth_state.py to use shared JSON helper while preserving existing error messages
- refactor src/mcat_cli/util/session_info.py to use shared JSON helper while preserving existing error messages
- add unit tests for JSON helper behavior: not found, invalid JSON, non-object payload, read errors, busy lock, canonical write format

## Validation
- uv run python -m unittest discover -s tests -p "test_*.py"
- uv run ruff check

Part of #24.