### PR TITLE
refactor: centralize CLI JSON input format parsing

### DIFF
--- a/src/mcat_cli/util/json_input.py
+++ b/src/mcat_cli/util/json_input.py
@@ -1,0 +1,61 @@
+from __future__ import annotations
+
+import json
+import sys
+from pathlib import Path
+from typing import Any, Callable
+
+
+def parse_json_or_json5(text: str, *, source: str) -> Any:
+    try:
+        return json.loads(text)
+    except json.JSONDecodeError as json_exc:
+        json_msg = json_exc.msg
+
+    try:
+        import json5
+    except ImportError:
+        raise ValueError(
+            f"invalid JSON in {source}: {json_msg} (install `json5` for JSON5 input)"
+        ) from None
+
+    try:
+        return json5.loads(text)
+    except Exception as exc:
+        raise ValueError(f"invalid JSON/JSON5 in {source}: {exc}") from None
+
+
+def parse_json_object_input(
+    input_value: str,
+    *,
+    label: str,
+    stdin_reader: Callable[[], str] | None = None,
+) -> dict[str, Any]:
+    spec = input_value.strip()
+    if not spec:
+        raise ValueError(f"{label} is required")
+
+    source = label
+    if spec == "@-":
+        source = "stdin"
+        text = (stdin_reader or sys.stdin.read)()
+    elif spec.startswith("@"):
+        path = spec[1:].strip()
+        if not path:
+            raise ValueError(
+                f"invalid {label} reference: missing file path after @"
+            )
+        source = path
+        try:
+            text = Path(path).read_text(encoding="utf-8")
+        except FileNotFoundError:
+            raise ValueError(f"{label} file not found: {path}") from None
+        except OSError as exc:
+            raise ValueError(f"unable to read {label} file {path}: {exc}") from None
+    else:
+        text = input_value
+
+    parsed = parse_json_or_json5(text, source=source)
+    if not isinstance(parsed, dict):
+        raise ValueError(f"{label} must be a JSON object")
+    return parsed

--- a/tests/test_json_input.py
+++ b/tests/test_json_input.py
@@ -1,0 +1,60 @@
+from __future__ import annotations
+
+import tempfile
+import unittest
+from pathlib import Path
+from unittest import mock
+
+from mcat_cli.util.json_input import parse_json_object_input
+
+
+class JsonInputTest(unittest.TestCase):
+    def test_parse_json_object_input_requires_value(self) -> None:
+        with self.assertRaisesRegex(ValueError, "ARGS is required"):
+            parse_json_object_input("   ", label="ARGS")
+
+    def test_parse_json_object_input_invalid_file_reference(self) -> None:
+        with self.assertRaisesRegex(
+            ValueError, "invalid ARGS reference: missing file path after @"
+        ):
+            parse_json_object_input("@   ", label="ARGS")
+
+    def test_parse_json_object_input_file_not_found(self) -> None:
+        with self.assertRaisesRegex(ValueError, "ARGS file not found: missing.json"):
+            parse_json_object_input("@missing.json", label="ARGS")
+
+    def test_parse_json_object_input_file_read_error(self) -> None:
+        with mock.patch("pathlib.Path.read_text", side_effect=OSError("permission denied")):
+            with self.assertRaisesRegex(
+                ValueError, "unable to read ARGS file data.json: permission denied"
+            ):
+                parse_json_object_input("@data.json", label="ARGS")
+
+    def test_parse_json_object_input_from_stdin(self) -> None:
+        parsed = parse_json_object_input(
+            "@-",
+            label="ARGS",
+            stdin_reader=lambda: '{"a":1}',
+        )
+        self.assertEqual(parsed, {"a": 1})
+
+    def test_parse_json_object_input_from_file_json5(self) -> None:
+        with tempfile.TemporaryDirectory() as temp_dir:
+            path = Path(temp_dir) / "args.json5"
+            path.write_text("{a: 1,}", encoding="utf-8")
+
+            parsed = parse_json_object_input(f"@{path}", label="ARGS")
+
+            self.assertEqual(parsed, {"a": 1})
+
+    def test_parse_json_object_input_must_be_object(self) -> None:
+        with self.assertRaisesRegex(ValueError, "ARGS must be a JSON object"):
+            parse_json_object_input("[]", label="ARGS")
+
+    def test_parse_json_object_input_invalid_json(self) -> None:
+        with self.assertRaisesRegex(ValueError, r"^invalid JSON/JSON5 in ARGS: "):
+            parse_json_object_input("{", label="ARGS")
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary
- add src/mcat_cli/util/json_input.py as the dedicated utility for CLI JSON/JSON5 input parsing
- move ARGS input parsing rules (direct JSON, @file, @-) out of src/mcat_cli/mcp.py
- keep current error messages and behavior while simplifying mcp.py orchestration
- add unit tests for required input, file/stdin input, JSON5 parsing, invalid references, and invalid payload shape

## Validation
- uv run ruff check
- uv run python -m unittest discover -s tests -p "test_*.py"

Part of #24.