### PR TITLE
docs: concise README and update mcat skill guide (#23)

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,17 +2,13 @@
 
 The model-context access tool for agents and humans.
 
-`mcat` is a CLI for agents to interact with MCP servers. An agent can learn the `mcat` skill and then work with any MCP server from only an endpoint.
+`mcat` is a CLI to interact with MCP servers from an endpoint.
 
 `mcat` provides:
-- `auth start`: start authorization and return action details (URL/code) for humans
-- `auth continue`: resume an auth flow paused for human assistance
+- `auth start`: start authorization and return action details (URL/code)
+- `auth continue`: resume a paused auth flow
 - `init`: run MCP `initialize` and store session info
 - `tool` / `resource` / `prompt`: access server capabilities
-
-Design principles:
-- no implicit defaults for core files; agents choose explicit paths for token/key, auth state, and session info
-- progressive disclosure; agents can start from an endpoint, complete auth/init, then use `tool list` to discover capabilities
 
 ## Install
 
@@ -28,9 +24,9 @@ uv tool install mcat-cli
 
 Requires Python 3.11+.
 
-## Agent-First Flow
+## Typical Flow
 
-1. Start auth (non-blocking, returns action details for the human):
+1. Start auth (non-blocking):
 
 ```bash
 mcat auth start https://mcp.example.com/mcp \
@@ -38,7 +34,7 @@ mcat auth start https://mcp.example.com/mcp \
   --state auth.json
 ```
 
-2. After the human finishes browser auth, continue:
+2. Continue auth after browser approval:
 
 ```bash
 mcat auth continue --state auth.json -k token.json

--- a/skills/mcat/SKILL.md
+++ b/skills/mcat/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: mcat
-description: "Use mcat for agent-first MCP workflows: authorize, initialize, discover capabilities, and call tools/resources/prompts with strict JSON handling."
+description: "Use mcat for MCP workflows: authorize, initialize, discover capabilities, and call tools/resources/prompts with strict JSON handling."
 ---
 
 # mcat Skill
 
-Use this workflow when an agent needs MCP access from shell commands.
+Use this workflow when MCP access is needed from shell commands.
 
 ## Install
 
@@ -24,7 +24,7 @@ uv tool install mcat-cli
 1. Treat stdout as machine-readable output.
 2. Parse `{"ok":true|false,...}` for normal commands.
 3. Treat non-zero exit as failure.
-4. Use explicit files chosen by the agent:
+4. Use explicit files:
    - auth state: `--state AUTH_STATE_FILE`
    - token/key destination/source: `-k/--key-ref`
    - session info: `-o/--out` for `init`, `-s/--session` for follow-up commands
@@ -67,16 +67,16 @@ mcat init ENDPOINT -k .env://.env:MCP_TOKEN -o sess.json
 
 For GitHub MCP use, existing PAT can be supplied through these env forms.
 
-## Agent-First Auth Flow
+## Auth Flow
 
-Default agent flow (non-blocking):
+Default non-blocking flow:
 
 ```bash
 mcat auth start ENDPOINT -k KEY_REF --state AUTH_STATE_FILE
 mcat auth continue --state AUTH_STATE_FILE -k KEY_REF
 ```
 
-`auth start` returns action details for the human to finish browser auth; the agent resumes with `auth continue`.
+`auth start` returns action details for browser approval; then resume with `auth continue`.
 
 Human direct flow:
 


### PR DESCRIPTION
Closes #23

## Summary
- refreshes `README.md` to be shorter and faster to scan
- updates `skills/mcat/SKILL.md` to match current CLI/auth/session behavior

## What changed
- README now focuses on install + minimal end-to-end flow (`auth start`, `auth continue`, `init`, and MCP calls)
- examples updated to current CLI options and argument order
- removed stale/extra wording and kept key reference + optional client config concise
- removed personal-name style example values in README

- Skill doc now includes current guidance for:
  - auth client config (`--client`, `--client-id`, `--client-secret`, `--client-name`)
  - provider error detail behavior in auth failures
  - stateless session initialization behavior (`session_mode: "stateless"` when no `mcp-session-id`)
  - help/usage behavior updates (top-level order and missing-arg usage rendering)

## Validation
- `uv run python -m unittest discover -s tests -p 'test_*.py'`
