### PR TITLE
chore: simplify PyPI metadata and add MIT license (#22)

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2026 Brice Yan
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,22 +3,15 @@ name = "mcat-cli"
 version = "0.1.6"
 description = "The model-context access tool for agents and humans"
 readme = "README.md"
-authors = [
-    { name = "Brice Yan", email = "briceyan3.0@gmail.com" }
-]
+license = "MIT"
+license-files = ["LICENSE"]
 keywords = [
     "mcp",
-    "cli",
+    "progressive disclosure",
+    "mcp debugging",
+    "client registration",
     "oauth",
 ]
-classifiers = [
-    "Development Status :: 3 - Alpha",
-    "Environment :: Console",
-    "Intended Audience :: Developers",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.11",
-]
-urls = { Repository = "https://github.com/briceyan/mcat-cli" }
 requires-python = ">=3.11"
 dependencies = [
     "dataclasses-json>=0.6,<1.0",


### PR DESCRIPTION
Closes #22

## Summary
- simplify package metadata in `pyproject.toml`
- add MIT `LICENSE` file
- align license metadata with modern packaging fields

## Changes
- removed `authors` from `[project]`
- removed `classifiers` from `[project]`
- removed `urls` from `[project]`
- set `keywords` exactly to:
  - `mcp`
  - `progressive disclosure`
  - `mcp debugging`
  - `client registration`
  - `oauth`
- added `license = "MIT"`
- added `license-files = ["LICENSE"]`
- added repository-level `LICENSE` file with standard MIT text

## Validation
- `uv build`
- verified generated metadata contains:
  - `License-Expression: MIT`
  - `License-File: LICENSE`
  - `Keywords: client registration,mcp,mcp debugging,oauth,progressive disclosure`
- verified generated metadata no longer contains:
  - `Author*`
  - `Classifier*`
  - `Project-URL*`
- `uv run ruff check`
